### PR TITLE
Add about page, cleanup some parts

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,3 +32,4 @@ gem "wdm", "~> 0.1.1", :platforms => [:mingw, :x64_mingw, :mswin]
 # Custom gems
 gem "jekyll-yamt"
 gem 'jekyll-watch'
+gem "webrick", "~> 1.7"

--- a/_config.yml
+++ b/_config.yml
@@ -8,6 +8,8 @@ baseurl: "" # the subpath of your site, e.g. /blog
 url: ""
 twitter_username: mc_parchment
 github_username:  ParchmentMC
+author:
+  name: ParchmentMC
 
 # Build settings
 theme: jekyll-yamt
@@ -32,7 +34,7 @@ lang: en_US
 
 #Highlighter
 kramdown:
-  input:          GFM
+  input: GFM
   syntax_highlighter: rouge
 
   syntax_highlighter_opts:
@@ -47,3 +49,7 @@ kramdown:
 sass:
   style: compressed
   sourcemap: never
+
+# Collections
+collections:
+ - team_members # ParchmentMC team members

--- a/_data/pages.yml
+++ b/_data/pages.yml
@@ -1,0 +1,2 @@
+pages:
+  - {name: 'About', url: 'about.html'}

--- a/_data/settings.yml
+++ b/_data/settings.yml
@@ -1,7 +1,7 @@
 #Subtitle
 subtitle:
   active: true
-  text: An extension to the official MojMaps containing parameter mappings and documentation.
+  text: Open community-sourced parameter names and javadocs.
 
 #Nav
 nav:

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,3 +1,3 @@
 <footer class= "footer">
-    <p>Copyright © {{ 'now' | date: "%Y" }} {{site.author.name}}. All rights reserved. Theme adapted from <a href="https://github.com/PandaSekh/Jekyll-YAMT">Jekyll-YAMT</a></p>
+    <p>Copyright © {{ 'now' | date: "%Y" }} {{site.author.name}}. Under the MIT License. Theme adapted from <a href="https://github.com/PandaSekh/Jekyll-YAMT">Jekyll-YAMT</a></p>
 </footer>

--- a/_team_members/alcatrazescapee.md
+++ b/_team_members/alcatrazescapee.md
@@ -1,0 +1,5 @@
+---
+name: AlcatrazEscapee
+teams: Mappings, Standards
+github: AlcatrazEscapee
+---

--- a/_team_members/baileyh.md
+++ b/_team_members/baileyh.md
@@ -1,0 +1,6 @@
+---
+name: BaileyH
+teams: Mappings
+github: BaileyH
+avatar: https://cdn.discordapp.com/avatars/159753108967129088/3598d940e97c3f6d7dfa6c14424ba030.webp?size=128
+---

--- a/_team_members/championash5357.md
+++ b/_team_members/championash5357.md
@@ -1,0 +1,6 @@
+---
+name: ChampionAsh5357
+role: Standards Lead
+teams: Mappings, Standards
+github: ChampionAsh5357
+---

--- a/_team_members/chylex.md
+++ b/_team_members/chylex.md
@@ -1,0 +1,5 @@
+---
+name: chylex
+teams: Mappings
+github: chylex
+---

--- a/_team_members/cyborgmas.md
+++ b/_team_members/cyborgmas.md
@@ -1,0 +1,5 @@
+---
+name: Cyborgmas
+teams: Mappings
+github: Cyborgmas
+---

--- a/_team_members/darkhax.md
+++ b/_team_members/darkhax.md
@@ -1,0 +1,5 @@
+---
+name: Darkhax
+teams: Mappings
+github: Darkhax
+---

--- a/_team_members/dolphintech.md
+++ b/_team_members/dolphintech.md
@@ -1,0 +1,5 @@
+---
+name: DolphinTech
+teams: Mappings
+github: DolphinTechCodes
+---

--- a/_team_members/gigaherz.md
+++ b/_team_members/gigaherz.md
@@ -1,0 +1,5 @@
+---
+name: gigaherz
+teams: Mappings
+github: gigaherz
+---

--- a/_team_members/jaredlll8.md
+++ b/_team_members/jaredlll8.md
@@ -1,0 +1,5 @@
+---
+name: Jared
+teams: Mappings
+github: jaredlll08
+---

--- a/_team_members/knightminer.md
+++ b/_team_members/knightminer.md
@@ -1,0 +1,5 @@
+---
+name: KnightMiner
+teams: Mappings
+github: KnightMiner
+---

--- a/_team_members/lanse505.md
+++ b/_team_members/lanse505.md
@@ -1,0 +1,6 @@
+---
+name: Lanse505
+role: Benevolent Dictator
+teams: Mappings
+github: Lanse505
+---

--- a/_team_members/mcenderdragon.md
+++ b/_team_members/mcenderdragon.md
@@ -1,0 +1,5 @@
+---
+name: MCenderdragon
+teams: Mappings
+github: mcenderdragon
+---

--- a/_team_members/mikey.md
+++ b/_team_members/mikey.md
@@ -1,0 +1,5 @@
+---
+name: Mikey
+teams: Mappings
+github: MichaelHillcox
+---

--- a/_team_members/oriononline.md
+++ b/_team_members/oriononline.md
@@ -1,0 +1,6 @@
+---
+name: OrionOnline
+role: System Admin
+teams: Mappings, Toolchain
+github: OrionDevelopment
+---

--- a/_team_members/raycoms.md
+++ b/_team_members/raycoms.md
@@ -1,0 +1,5 @@
+---
+name: Raycoms
+teams: Mappings
+github: Raycoms
+---

--- a/_team_members/sciwhiz12.md
+++ b/_team_members/sciwhiz12.md
@@ -1,0 +1,6 @@
+---
+name: sciwhiz12
+role: Toolchain Lead
+teams: Toolchain, Mappings
+github: sciwhiz12
+---

--- a/_team_members/sekwah.md
+++ b/_team_members/sekwah.md
@@ -1,0 +1,5 @@
+---
+name: Sekwah
+teams: Mappings
+github: sekwah41
+---

--- a/_team_members/sizableshrimp.md
+++ b/_team_members/sizableshrimp.md
@@ -1,0 +1,5 @@
+---
+name: SizableShrimp
+teams: Mappings, Standards
+github: SizableShrimp
+---

--- a/_team_members/skysom.md
+++ b/_team_members/skysom.md
@@ -1,0 +1,5 @@
+---
+name: SkySom
+teams: Mappings
+github: SkySom
+---

--- a/about.md
+++ b/about.md
@@ -1,0 +1,57 @@
+---
+layout: default
+title: About
+---
+
+**ParchmentMC** is a community project to provide a cohesive set of mappings of parameter names and javadocs, to augment the official names released by Mojang.
+
+## The Team
+
+<style>
+.team-container {
+  margin: 1em;
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  column-gap: 1em;
+  row-gap: 1em;
+  text-align: center;
+}
+
+.team-container .avatar {
+  width: 100%;
+  border: 2px solid black;
+  border-radius: 100%;
+}
+
+.team-container .name {
+  font-weight: bold;
+  font-size: 1.1em;
+}
+
+.team-container .role {
+  font-weight: 500;
+  text-decoration: underline;
+  font-size: 0.9em;
+}
+
+.team-container .teams {
+  font-style: italic;
+  font-size: 0.8em;
+}
+
+</style>
+
+<div class="team-container">
+{% for team_member in site.team_members %}
+  <div class="member">
+    {% capture avatar %}
+    https://github.com/{{ team_member.github }}.png
+    {% endcapture %}
+    {% if team_member.avatar %} {% assign avatar = team_member.avatar %} {% endif %}
+    <img class="avatar" src="{{ avatar }}">
+    <div class="name">{{ team_member.name }}</div>
+    <div class="role">{{ team_member.role }}</div>
+    <div class="teams">{{ team_member.teams }}</div>
+  </div>
+{% endfor %}
+</div>


### PR DESCRIPTION
Adds an about page with team member boxes/icons, adds the `webrick` gem (so jekyll doesn't fall on its face because its missing on Ruby 3.0), does some other miscellaneous cleanup.