### PR TITLE
Copy and improve mapping standards and review process

### DIFF
--- a/_data/pages.yml
+++ b/_data/pages.yml
@@ -1,4 +1,7 @@
 pages:
-  - {name: 'About', url: 'about.html'}
-  - {name: 'Discord', url: 'discord.html'}
-  - {name: 'Documentation', url: 'docs/'}
+  - name: 'About'
+    url: 'about'
+  - name: 'Discord'
+    url: 'discord'
+  - name: 'Documentation'
+    url: 'docs/'

--- a/_data/pages.yml
+++ b/_data/pages.yml
@@ -1,3 +1,4 @@
 pages:
   - {name: 'About', url: 'about.html'}
   - {name: 'Discord', url: 'discord.html'}
+  - {name: 'Documentation', url: 'docs/'}

--- a/_team_members/baileyh.md
+++ b/_team_members/baileyh.md
@@ -1,5 +1,5 @@
 ---
 name: BaileyH
 github: BaileyH
-avatar: https://cdn.discordapp.com/avatars/159753108967129088/3598d940e97c3f6d7dfa6c14424ba030.webp?size=128
+avatar: https://cdn.discordapp.com/avatars/159753108967129088/cba59ee1d01ebb0e2085dea39c868ad3.webp?size=128
 ---

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,9 @@
+---
+layout: page
+title: "Documentation"
+---
+
+# Documentation
+
+ * [Mapping Standards](mappings)
+ * [Review Process](review)

--- a/docs/mappings.md
+++ b/docs/mappings.md
@@ -1,0 +1,55 @@
+---
+layout: page
+title: Mapping Standards
+---
+
+# Mapping Standards
+
+This document details the standards that all contributions to Parchment mappings must follow.
+
+### Parameter Names
+
+1. Use American English for spellings
+    - Example: `color`, not `colour`, `armor`, not `armour`
+1. Names should make sense and be valid java identifiers NOT reserved keywords as such:
+    - Example: `float` is NOT valid as it is a reserved keyword.
+1. Parameter names may be named based on the types, and the context in which they are used. They should be verbose and use complete words - do not omit essential information for brevity's sake.
+    - Example: `BlockPos adjacentPos, BlockPos currentPos`, not `BlockPos pos1, BlockPos pos2`
+1. Avoid single letters, or abbreviations.
+    - Example: `northWest` over `nW`, `matrixStack` over `mStack`. 
+    - Exception: common abbreviations can be used: `IO` / `NBT`, etc.
+    - Exception: common class / parameter names can be shortened: `BlockPos pos, BlockState state, WorldGenLevel level`
+1. Use Lower Camel Case.
+    - Example: `lowerCamelCase`
+3. Do not use `$` or `_` in variable names
+4. All parameters should match the regex `[a-z][A-Za-z0-9]*`.
+    - Simply, parameters should contain only alphanumeric characters and start with a lowercase letter.
+    - Example: `dot`, `pos`, `blockState`
+5. Favor using Mojang / Mojmap class names over <1.17 MCP classes to name parameters. In general, the mojmap name is the de-facto standard.
+    - Example: Use `level` over `world`, `blockEntity` over `tileEntity`
+    - Exception: If a Mojmap name would otherwise break a previous rule (i.e. `setColour(int)`, which would imply a parameter of `colour`, is not American English)
+
+
+A note about lambda parameters: They can, and will conflict with both existing variables, other methods, and other lambdas. Care should be taken to review these, until such a time that an automated and/or testable solution is in place to verify that these cannot conflict.  
+
+### Javadocs
+
+Prioritization:
+
+- Prioritize documenting public APIs over private fields and methods.
+- Prioritize methods and parameters, important fields, and classes.
+- Follow the principle of least effort for best payoff!
+- Do not document `package-info.java`.
+
+Content:
+
+1. Fully qualified mojmap class names should be used in javadoc tags that resolve their content, aka `@link` and `@see`.
+    - Example: `{@link net.minecraft.math.BlockPos}` instead of `{@link BlockPos}`
+2. Javadocs should be informative - there is no explicit restrictions as long as it is useful.
+3. Avoid overly simple explanations, or “expected knowledge”:
+    - Example: `getWorld() // Gets the world, @return the world`. This not a useful contribution.
+    - Example: `BlockPos() {} // This is the constructor for the class BlockPos` This is expected knowledge - javadocs should not be used to document Java itself.
+4. You can use the `@return` tag in a javadoc.
+5. Do not use `@param` tags directly in method javadocs, use the parameter javadocs instead.
+6. Do not use `@author` or `@since` tags in javadocs.
+7. Try to avoid overly specific examples or code references as they may go “out of date” in future Minecraft versions.

--- a/docs/mappings.md
+++ b/docs/mappings.md
@@ -45,7 +45,7 @@ As a general standard, use American English spelling for words. For example, pre
     - {:.small-text} _Examples:_ `BlockPos adjacentPos, BlockPos currentPos`, not `BlockPos pos1, BlockPos pos2`
 
 1. **Avoid abbreivations or acronyms.**
-    - _Exception:_ Common or well-known abbreviations can be used: `IO` (input-output), `NBT` ([named binary tag][nbt])
+    - _Exception:_ Common or well-known abbreviations can be used: `IO` (input-output), `Id` (identifier)
     - _Exception:_ Names for common classes can be shortened: `BlockPos pos`, `BlockState state`, `WorldGenLevel level`
 
 > **Note about lambda parameters:**
@@ -117,4 +117,3 @@ their corresponding fields.
       is moved, refactored, or deleted.
 
 *[mojmap]: portmanteau of 'Mojang' and 'mappings'
-[nbt]: https://minecraft.fandom.com/wiki/NBT_format

--- a/docs/mappings.md
+++ b/docs/mappings.md
@@ -3,53 +3,118 @@ layout: page
 title: Mapping Standards
 ---
 
+<style>
+.small-text {
+    list-style: none;
+    font-size: 0.9em !important;
+}
+.list-separation > li {
+    margin-bottom: 0.5em;
+}
+</style>
+
 # Mapping Standards
 
-This document details the standards that all contributions to Parchment mappings must follow.
+To ensure consistency for the Parchment mapping data, both to the benefit of reviewers and to consumers of the mappings,
+this page shows the mapping standards and guidelines. These standards are the basis used by reviewers when checking
+contributions.
 
-### Parameter Names
+The Parchment mapping set is based off of the names provided by the obfuscation maps that Mojang publishes for all 
+versions since 1.14. These names are referred to by Parchment as **'official'** names, **'Mojang'** names, or 
+**'mojmap'** names, in contrast to the _'obfuscated'_ names found in the client and server JARs.
 
-1. Use American English for spellings
-    - Example: `color`, not `colour`, `armor`, not `armour`
-1. Names should make sense and be valid java identifiers NOT reserved keywords as such:
-    - Example: `float` is NOT valid as it is a reserved keyword.
-1. Parameter names may be named based on the types, and the context in which they are used. They should be verbose and use complete words - do not omit essential information for brevity's sake.
-    - Example: `BlockPos adjacentPos, BlockPos currentPos`, not `BlockPos pos1, BlockPos pos2`
-1. Avoid single letters, or abbreviations.
-    - Example: `northWest` over `nW`, `matrixStack` over `mStack`. 
-    - Exception: common abbreviations can be used: `IO` / `NBT`, etc.
-    - Exception: common class / parameter names can be shortened: `BlockPos pos, BlockState state, WorldGenLevel level`
-1. Use Lower Camel Case.
-    - Example: `lowerCamelCase`
-3. Do not use `$` or `_` in variable names
-4. All parameters should match the regex `[a-z][A-Za-z0-9]*`.
-    - Simply, parameters should contain only alphanumeric characters and start with a lowercase letter.
-    - Example: `dot`, `pos`, `blockState`
-5. Favor using Mojang / Mojmap class names over <1.17 MCP classes to name parameters. In general, the mojmap name is the de-facto standard.
-    - Example: Use `level` over `world`, `blockEntity` over `tileEntity`
-    - Exception: If a Mojmap name would otherwise break a previous rule (i.e. `setColour(int)`, which would imply a parameter of `colour`, is not American English)
+As a general standard, use American English spelling for words. For example, prefer `color` to `colour`, or `armor` to
+`armour`.
 
+## Parameter Names
 
-A note about lambda parameters: They can, and will conflict with both existing variables, other methods, and other lambdas. Care should be taken to review these, until such a time that an automated and/or testable solution is in place to verify that these cannot conflict.  
+{:.list-separation}
 
-### Javadocs
+1. **Names must only contain alphanumeric characters, and must begin with a lowercase letter.**
+    - Alphanumeric characters means the characters in the ranges `A-Z`, `a-z`, and `0-9`.
+    - {:.small-text} _Examples:_ `someVariable`, not `delta%` or `Delta`
 
-Prioritization:
+1. **Names must be in lower camel case.**
+    - Lower camel case is written by joining together words and capitalizing the first character of each word except 
+      the first.
+    - {:.small-text} _Examples:_ `lowerCamelCase`, `areaTransformer`, `generatedItem`
 
-- Prioritize documenting public APIs over private fields and methods.
-- Prioritize methods and parameters, important fields, and classes.
-- Follow the principle of least effort for best payoff!
-- Do not document `package-info.java`.
+1. **Names should be named based on the parameter types and context of use.**
+    - They should be verbose and use complete words. Avoid omitting essential information for the purpose of keeping the 
+      name compact.
+    - {:.small-text} _Examples:_ `BlockPos adjacentPos, BlockPos currentPos`, not `BlockPos pos1, BlockPos pos2`
 
-Content:
+1. **Avoid abbreivations or acronyms.**
+    - _Exception:_ Common or well-known abbreviations can be used: `IO` (input-output), `NBT` ([named binary tag][nbt])
+    - _Exception:_ Names for common classes can be shortened: `BlockPos pos`, `BlockState state`, `WorldGenLevel level`
 
-1. Fully qualified mojmap class names should be used in javadoc tags that resolve their content, aka `@link` and `@see`.
-    - Example: `{@link net.minecraft.math.BlockPos}` instead of `{@link BlockPos}`
-2. Javadocs should be informative - there is no explicit restrictions as long as it is useful.
-3. Avoid overly simple explanations, or “expected knowledge”:
-    - Example: `getWorld() // Gets the world, @return the world`. This not a useful contribution.
-    - Example: `BlockPos() {} // This is the constructor for the class BlockPos` This is expected knowledge - javadocs should not be used to document Java itself.
-4. You can use the `@return` tag in a javadoc.
-5. Do not use `@param` tags directly in method javadocs, use the parameter javadocs instead.
-6. Do not use `@author` or `@since` tags in javadocs.
-7. Try to avoid overly specific examples or code references as they may go “out of date” in future Minecraft versions.
+> **Note about lambda parameters:**
+> 
+> Currently, there is no fullly automated solution for verifying that mapped lambda parameters do not conflict with 
+> parameters (both method and other lambdas) or local variables. Care should be taken when naming and reviewing these.
+> 
+> As a workaround, Parchment has a 'checked' export which, among other things, strips out names for lambda parameters,
+> so projects which require non-conflicting parameter names (such as for recompilation of decompiled source) may use 
+> that instead.
+
+## Javadocs
+
+When documenting, try to keep explanations simple and concise without sacrificing accuracy. Avoid use of overly complex
+or lengthy words where simple and short words are sufficient.
+
+Documenting members should be prioritized into the following: public members, then important members, then non-obvious 
+members (commonly, getters which return numbers or opaque objects, such as NBT tags.) Methods should be documented over
+their corresponding fields.
+
+{:.list-separation}
+
+1. **Use fully qualified class names in javadoc tags which link to classes or their members.**
+    - Some of these javadoc tags are `{@link}` and `@see`.
+    - {:.small-text} _Example:_ `{@link net.minecraft.math.BlockPos}` instead of `{@link BlockPos}`.
+
+1. **Avoid adding overly simple information or "expected knowledge".**
+    - "Expected knowledge" means any fundamental knowledge of either Java or Minecraft which is assumed to be known by
+      any developer.
+        - {:.small-text} _Example:_ 
+
+          ```java
+          /**
+           * Constructor for a BlockPos
+           */
+          public BlockPos(...) { ... }
+          ```
+
+          This is expected knowledge; developers are expected to be able to identify a constructor in Java.
+          {:.small-text} 
+
+    - Overly simple information means javadocs which does not give any information that cannot be immediately inferred 
+      from the code. This explicity excludes javadocs which gives information that is not immediately inferrable, such
+      as the valid range of a number from a getter.
+        - {:.small-text} _Example:_ 
+
+          ```java
+          /**
+           * Returns the level.
+           *
+           * @return the level
+           */
+          public Level getLevel() { return this.level; }
+          ```
+
+          The knowledge of what the getter returns is immediately inferrable from the code and the getter name.
+          {:.small-text} 
+
+1. **Do not use the following javadoc tags:** `@author`, `@since`, `@param`.
+    - Due to the nature of the mapping data being made for Minecraft, a game made by Mojang Studios, it is inapproriate
+      to use the `@author` to mark the contributor for that javadoc.
+    - Because of the dynamic nature of the game code, it would be difficult to determine and maintain the approriate
+      `@since` tags for javadocs.
+    - Parameter javadocs should be specified at the parameter level. It is up to consumers of the mapping data to insert
+      `@param` entries for each named and documented parameter.
+
+1. **Avoid including overly specific code examples of game code.**
+    - These code examples may become out-of-date and incorrect in future Minecraft versions as the code they reference 
+      is moved, refactored, or deleted.
+
+*[mojmap]: portmanteau of 'Mojang' and 'mappings'
+[nbt]: https://minecraft.fandom.com/wiki/NBT_format

--- a/docs/review.md
+++ b/docs/review.md
@@ -1,0 +1,29 @@
+---
+layout: page
+title: PR Review Process
+---
+
+# Mappings Review / Merge Process
+
+This document details the review and merge process for Parchment mappings.
+
+### Requirements to merge:
+
+1. All reviews and suggestions from community members are welcome.
+1. All automatic tests must pass:
+    - The Contributor License Agreement (CLA) must be signed.
+1. A PR requires two approving reviews
+    - One approving review is required to be from a member of the ParchmentMC mapping reviewers team.
+    - The other review can be anyone except the original author.
+    - We ask that people don’t review things that they don’t actually have the capability to effectively review (knowledge wise).
+1. After a PR has been approved, it must wait at least 48 hours for any further comments (or, 24 hours if it is deemed to be only minor changes.)
+1. After the required waiting period, if there are no reviews that are requesting changes from a member of the mapping reviewers team then the PR will be merged.
+1. If, after such waiting period, there are members from the mapping reviewers team requesting changes, then those changes must be addressed before the PR can be merged, or go into the waiting period again.
+1. If a PR is generating conflicting opinions, it may be put to a fixed length comment period, where everyone is open to discuss changes to the PR. After the comment period, lasting at most one week, it will be put to a vote between the ParchmentMC mapping reviewers team as to whether it should be merged or not.
+1. Submissions should be substantial, although are not required to have any 'minimum contribution' to be considered
+    - Prefer submitting one PR containing a number of smaller unrelated contributions, than many PRs containing very small contributions.
+    - On the other hand, do not lump together otherwise unrelated PR contributions unless there is a reason to do so (i.e. the unrelated contributions are small and can be easily extended)
+1. PRs are merged and squashed, linked back to the author.
+
+
+Note: the phrase "ParchmentMC mapping reviewers team" refers to the members of [the github team of the same name](https://github.com/orgs/ParchmentMC/teams/mapping-reviewers).

--- a/docs/review.md
+++ b/docs/review.md
@@ -3,27 +3,106 @@ layout: page
 title: PR Review Process
 ---
 
-# Mappings Review / Merge Process
+<style>
+.fa-ul.outline .fa-li {
+    font-size: 1.3em;
+    width: 2.25em;
+}
+</style>
 
-This document details the review and merge process for Parchment mappings.
+# PR Review Process
 
-### Requirements to merge:
+All contributions to the Parchment mappings data are reviewed and merged according to this process. This ensures
+transparency between the mappings contributors and the ParchmentMC team, and allows contributors to assess at what
+stage their PR is at.
 
-1. All reviews and suggestions from community members are welcome.
-1. All automatic tests must pass:
+## Responsible Teams
+
+The **Parchment mappings team** is responsible for the whole process, and is split into two relevant subteams:
+
+- The **reviewers subteam** has the responsbility of reviewing PRs and merging them, pursuant to this process.
+- The **standards subteam** has the responsibility of maintaining and approving changes to the standards and the 
+  process, and decide on matters relating to the mapping standards.
+
+The **repository administrators** have full admin access to the repository and may forcefully merge a Pull Request,
+overriding any technical requirements on PRs such as status checks. This privilege should only be used in cases where 
+no other remedies are available, such as emergency situations, malfunctioning status checks, or otherwise.
+
+Only members of the reviewers subteam and repository administrators can merge PRs into the main versioned branches.
+
+## PR Requirements
+
+Pull Requests must abide by these requirements:
+
+- All automatic checks are successful.
     - The Contributor License Agreement (CLA) must be signed.
-1. A PR requires two approving reviews
-    - One approving review is required to be from a member of the ParchmentMC mapping reviewers team.
-    - The other review can be anyone except the original author.
-    - We ask that people don’t review things that they don’t actually have the capability to effectively review (knowledge wise).
-1. After a PR has been approved, it must wait at least 48 hours for any further comments (or, 24 hours if it is deemed to be only minor changes.)
-1. After the required waiting period, if there are no reviews that are requesting changes from a member of the mapping reviewers team then the PR will be merged.
-1. If, after such waiting period, there are members from the mapping reviewers team requesting changes, then those changes must be addressed before the PR can be merged, or go into the waiting period again.
-1. If a PR is generating conflicting opinions, it may be put to a fixed length comment period, where everyone is open to discuss changes to the PR. After the comment period, lasting at most one week, it will be put to a vote between the ParchmentMC mapping reviewers team as to whether it should be merged or not.
-1. Submissions should be substantial, although are not required to have any 'minimum contribution' to be considered
-    - Prefer submitting one PR containing a number of smaller unrelated contributions, than many PRs containing very small contributions.
-    - On the other hand, do not lump together otherwise unrelated PR contributions unless there is a reason to do so (i.e. the unrelated contributions are small and can be easily extended)
-1. PRs are merged and squashed, linked back to the author.
+    - The data validation test from the CI must pass, and there must be no validation errors.
+
+- Contributions should be substantial.
+    - While this requires PRs be substantial, there is no 'minimum contribution' requirement or definition.
+    - Prefer submitting one PR containing a number of smaller unrelated contributions, than many PRs containing very 
+      small contributions.
+    - A PR should preferrably be reasonable in scope, such as mapping a package or adjusting javadocs. Large unrelated 
+      changes should be made in separate PRs.
+
+- Contributions must abide by the [Parchment mapping standards](standards).
 
 
-Note: the phrase "ParchmentMC mapping reviewers team" refers to the members of [the github team of the same name](https://github.com/orgs/ParchmentMC/teams/mapping-reviewers).
+## Outline
+
+{:.fa-ul .outline}
+- <span class="fa-li"><i class="fas fa-code-branch"></i></span> 
+  A contributor submits a Pull Request to the mappings repository with their contributions. This PR will await 
+  triaging by a mappings team member.
+
+- <span class="fa-li"><i class="fas fa-search"></i></span>
+  A mappings team member will perform a cursory inspection of the changes in the PR.
+
+    - All automatic checks must pass before it is labelled and starts review.
+    - The cursory inspection is to ensure that the changes in the PR do not contain any content not fit for the 
+      repository.
+    - Once the triaging member has performed a cursory inspection and does not find any objectively objectionable 
+      content and the automatic checks succeed, it is labelled accordingly by version and contents and a review is 
+      requested from the reviewers subteam.
+
+- <span class="fa-li"><i class="fas fa-comments"></i></span> 
+  The PR will now be reviewed by at least one (1) member of the reviewers subteam, and at least by two people.
+
+  For a PR to be considered for merging, it must have at least two (2) approving reviews without any unresolved 
+  conversations and no change requesting reviews. One (1) approving review must be from a member of the reviewers 
+  subteam.
+
+- <span class="fa-li"><i class="fas fa-hourglass-start"></i> </span>
+  After a PR has passed the review requirements above, a waiting period of at least forty-eight (48) hours for any 
+  further comments or reviews will begin.
+
+    - For minor changes, a member of the reviewers subteam may reduce the waiting period to twenty-four (24) hours.
+    - For PRs which generate conflicting opinions or large discussions, the PR may be placed under a fixed-length 
+      discussion period (see the following section).
+
+- <span class="fa-li"><i class="fas fa-hourglass-end"></i> </span>
+  Once the waiting period has elasped without any futher change requesting reviews from any mappings team member, or 
+  a fixed-length discussion period has elapsed (see following section), it will be assigned to the reviewers subteam 
+  for merging.
+
+- <span class="fa-li"><i class="fas fa-code-branch"></i></span>
+  An available member of the reviewers subteam will then squash-merge the PR, integrating the changes into the 
+  target branch.
+
+## Fixed-Length Discussion
+
+If a PR generates conflicting opinions and reivews or creates a large discussion that warrants an extended period of
+time for discussion, the reviewers subteam may place the PR under a fixed-length discussion period. During the 
+fixed-length period, discussions may freely occur between reviews on the PR. 
+
+After this period has elapsed, the reviewers subteam will hold an internal vote on whether the PR shall be merged.
+If a majority votes in favor, then the PR shall be assigned for merging. If a majority votes in dissent, then the PR 
+shall be closed. For a tie, the whole mappings team will vote, and a tie will mean the PR shall be closed. A majority 
+is defined as more than fifty percent (50%) of the voters.
+
+### Length
+
+The length of the discussion will last at least forty-eight (48) hours, and at most one (1) week. If the discussion 
+does not yet seem to have reached a conclusion, the designated fixed length of the discussion is less or equal to 
+seventy-two (72) hours, and the fixed length has not yet been extended, then the fixed-length discussion period may be 
+extended by up to forty-eight (48) hours, upon the consensus of the reviewers subteam.

--- a/docs/review.md
+++ b/docs/review.md
@@ -72,6 +72,14 @@ Pull Requests must abide by these requirements:
   conversations and no change requesting reviews. One (1) approving review must be from a member of the reviewers 
   subteam.
 
+    - If all review comments of a change requesting review from a member of the reviewers subteam have been resolved, 
+      and more than five (5) days have passed since the resolution of these review comments, then the review may be 
+      dismissed as being outdated.
+
+      This prevents situations where a reviewer requests changes on a PR then becomes unable to rereview the PR for an 
+      extended period of time, which blocks the PR from being considered for merging (as a change requesting review is
+      present on the PR from a member of the reviewers subteam).
+
 - <span class="fa-li"><i class="fas fa-hourglass-start"></i> </span>
   After a PR has passed the review requirements above, a waiting period of at least forty-eight (48) hours for any 
   further comments or reviews will begin.


### PR DESCRIPTION
Documentation was initially copied from https://github.com/ParchmentMC/Parchment/tree/a767e3da111d28ba50d85000c584cec6aa888b40/docs from the mappings repo.

/cc @ParchmentMC/mapping-standards for reviewing the PR's additions and changes to the mapping standards and review process.