### PR TITLE
Add version policy

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -8,3 +8,4 @@ title: "Documentation"
  * [Mapping Standards](mappings.html)
  * [Review Process](review.html)
  * [Maven Repository and Artifacts](maven.html)
+ * [Version Policy](versions.html)

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,6 +6,6 @@ title: "Documentation"
 # Documentation
 
  * [Mapping Standards](mappings.html)
- * [Review Process](review.html)
  * [Maven Repository and Artifacts](maven.html)
+ * [Review Process](review.html)
  * [Version Policy](versions.html)

--- a/docs/versions.md
+++ b/docs/versions.md
@@ -1,0 +1,38 @@
+---
+layout: page
+title: Version Policy
+---
+
+# Version Policy
+
+ParchmentMC maintains a version policy to specify what versions of Minecraft are prioritized by the ParchmentMC team 
+for actively reviewing contributions. 
+
+Due to the technical and design requirements of the toolchain, Parchment only supports versions of Minecraft which has 
+published obfuscation logs.
+
+Each major version or release of Minecraft which Parchment maintains a mapping set for will have one branch. All minor 
+versions associated with that major versions are included into that one branch. Only the latest minor version of each 
+major release will be supported.
+
+The latest minor version of the latest major release will be the actively reviewed version, and is the recommended 
+target for contributions. While contributions to older major versions will not be rejected, they will be lower in 
+priority for review.
+
+If it is known that the latest minor version of the latest major release has major game-breaking bugs and there is a 
+hotfix version in preparation, the mappings team may choose to skip that minor version in favor of waiting for the 
+hotfix version.
+
+When the mappings team is satisfied as to the (full or majority) completion of the mappings for the latest minor version
+of the latest major release, they may designate another recommended target for contributions.
+
+## Snapshots
+
+Due to the nature of snapshot versions being a snapshot of the development of Minecraft and therefore being inherently 
+unstable, the ParchmentMC team is not yet comfortable to the mapping of snapshot versions, as efforts to map a snapshot 
+version may be invalidated by the next snapshot.
+
+Additionally, the team feels that mapping efforts should be focused on the latest released version, as that is the 
+version most likely in use by the end consumers of the Parchment mapping data. As stated above, if it ever passes that
+the mappings team feels that the latest release has been mapped fully, they may designate another target for focusing
+the current mapping efforts, such as (possibly) snapshot versions.

--- a/docs/versions.md
+++ b/docs/versions.md
@@ -8,7 +8,7 @@ title: Version Policy
 ParchmentMC maintains a version policy to specify what versions of Minecraft are prioritized by the ParchmentMC team 
 for actively reviewing contributions. 
 
-Due to the technical and design requirements of the toolchain, Parchment only supports versions of Minecraft which has 
+Due to the technical and design requirements of the toolchain, Parchment only supports versions of Minecraft which have 
 published obfuscation logs.
 
 Each major version or release of Minecraft which Parchment maintains a mapping set for will have one branch. All minor 

--- a/docs/versions.md
+++ b/docs/versions.md
@@ -15,9 +15,8 @@ Each major version or release of Minecraft which Parchment maintains a mapping s
 versions associated with that major versions are included into that one branch. Only the latest minor version of each 
 major release will be supported.
 
-The latest minor version of the latest major release will be the actively reviewed version, and is the recommended 
-target for contributions. While contributions to older major versions will not be rejected, they will be lower in 
-priority for review.
+The two latest major releases will be the actively reviewed versions, and are the recommended targets for contributions. 
+While contributions to older major versions will not be rejected, they will be lower in priority for review.
 
 If it is known that the latest minor version of the latest major release has major game-breaking bugs and there is a 
 hotfix version in preparation, the mappings team may choose to skip that minor version in favor of waiting for the 


### PR DESCRIPTION
The version policy is based on the discussions done in the [`#parchment-mappings` channel] of the public discord.

In summary, the policy states that we support only the latest minor version of each major release. Mapping and reviewing efforts are focused on the latest minor version of the latest major release, and may be retargeted if the mappings team feels that it is mapped to a majority or fully. Snapshots are not yet to be mapped, unless the mappings team retargets to the snapshots.

/cc @ParchmentMC/mapping-standards to review the contents of the version policy, @ParchmentMC/mappings for any objections (and to inform of the new policy).