### PR TITLE
Standards revisions.

### DIFF
--- a/docs/mappings.md
+++ b/docs/mappings.md
@@ -52,17 +52,6 @@ As a general standard, use American English spelling for words. For example, pre
 
 ## Javadocs
 
-Write sentences for class, method and field javadocs, starting with an uppercase and ending with a period. When
-documenting, try to keep explanations simple and concise without sacrificing accuracy. Avoid use of overly complex
-or lengthy words where simple and short words are sufficient.
-
-Descriptions on `@return` and `@param` entries may be incomplete sentences or phrases, such as 
-
-Do not insert line breaks for overlong columns. (The `.mapping` files should use single line `COMMENT` lines unless an
-an explicit line break in the javadoc comment is desired.) Use `<p>` tags on empty `COMMENT` lines if a line break is
-desired in the generated rendered view of the javadocs.
-
-
 {:.list-separation}
 
 1. **Use complete, meaningful, concise sentences**

--- a/docs/mappings.md
+++ b/docs/mappings.md
@@ -118,8 +118,19 @@ As a general standard, use American English spelling for words. For example, pre
       This can happen under the following cases:
       - The class is from the `java.lang` package.
       - The class is in the same package as the current class.
-      - The class is an inner class of the current class.
-    - {:.small-text} _Example:_ `{@link net.minecraft.math.BlockPos}` instead of `{@link BlockPos}`.
+      - The class is *used* by this class, as in, it is used as a field type, or method parameter within this class.
+    - {:.small-text} _Example:_
+
+      ```java
+      /**
+       * Use the fully qualified name to reference classes from another package.
+       * @see other.package.Foo
+       * Classes from java.lang or the same package can be referenced without fully qualified names.
+       * @see String
+       * This class, or classes used by this class can be referenced without fully qualified names.
+       * @see #someMethod(Baz, Bar)
+       */
+      ```
 
 1. **Avoid adding overly simple information or "expected knowledge".**
     - "Expected knowledge" means any fundamental knowledge of either Java or Minecraft which is assumed to be known by

--- a/docs/mappings.md
+++ b/docs/mappings.md
@@ -42,9 +42,25 @@ As a general standard, use American English spelling for words. For example, pre
 1. **Names should be named based on the parameter types and context of use.**
     - They should be verbose and use complete words. Avoid omitting essential information for the purpose of keeping the 
       name compact.
-    - Use the surrounding mojang class, field, and method names to infer parameter names. Prefer matching the mojang naming
-      rather than trying to improve on it.
     - {:.small-text} _Examples:_ `BlockPos adjacentPos, BlockPos currentPos`, not `BlockPos pos1, BlockPos pos2`
+    - Use the surrounding Mojang class, field, and method names to infer parameter names. Prefer matching the Mojang naming
+      rather than trying to improve on it.
+      - If matching the mojang name leaves a parameter's usage unclear, consider adding a parameter javadoc with an
+        explanation of that parameter.
+    - {:.small-text} _Example:_
+
+      ```java
+      private boolean cantTouchThis;
+
+      /**
+       * @param cantTouchThis If the parameter name is unclear, a parameter javadoc could be added to explain the
+       *                      usage in more detail.
+       */
+      public Foo(boolean cantTouchThis) { // Note this parameter is named to match the field name
+        this.cantTouchThis = cantTouchThis;
+      } 
+
+      ```
 
 1. **Avoid abbreivations or acronyms.**
     - _Exception:_ Common or well-known abbreviations can be used: `IO` (input-output), `Id` (identifier).
@@ -57,22 +73,23 @@ As a general standard, use American English spelling for words. For example, pre
 1. **Use complete, meaningful, concise sentences**
     - Try and keep explanations simple and concise without sacrificing accuracy. Avoid the use of overly complicated 
       words where short and simple descriptions are sufficient.
-    - Avoid the use of domain specific knowledge that the reader would not be assumed to have if it is not necessary.
+    - Avoid the use of domain specific knowledge that the reader would not be expected to know if a simpler or clearer
+      explanation can be found.
     - Write complete sentences for documentation, starting with an uppercase letter and ending with a period.
-    - _Exception:_ Phrases in `@return` or `@param` may use short phrases that are not sentences.
+    - _Exception:_ Descriptions in `@return`, `@param`, or `@throws` may use short phrases that are not sentences.
       - {:.small-text} _Example:_
         
         ```java
         /**
          * This is a full sentence. It begins with a capital letter and ends with a period.
-         * Note that the below two tags may, and are allowed, to use short phrases rather than complete sentences.
+         * Note that the below two lines may use short phrases rather than complete sentences.
          * @param foo the current foo
          * @return the modified foo
          */
         ```
 
 1. **Do not insert unnesecary line breaks.**
-    - Do not manually insert line breaks for long columns, or try and manually hard wrap sentences.
+    - Do not manually insert line breaks for long lines, or explicitly hard wrap sentences.
       - Each new `COMMENT` line will insert a line break in the comment, and column limits are enforced by end mapping consumers.
     - Do use line breaks if there is a logical need to start a paragraph in the javadoc comment.
       - {:.small-text} _Example:_

--- a/docs/mappings.md
+++ b/docs/mappings.md
@@ -32,7 +32,7 @@ As a general standard, use American English spelling for words. For example, pre
 
 1. **Names must only contain alphanumeric characters, and must begin with a lowercase letter.**
     - Alphanumeric characters means the characters in the ranges `A-Z`, `a-z`, and `0-9`.
-    - {:.small-text} _Examples:_ `someVariable`, not `delta%` or `Delta`
+    - {:.small-text} _Examples:_ `someVariable`, not `delta$` or `Delta`
 
 1. **Names must be in lower camel case.**
     - Lower camel case is written by joining together words and capitalizing the first character of each word except 
@@ -42,34 +42,77 @@ As a general standard, use American English spelling for words. For example, pre
 1. **Names should be named based on the parameter types and context of use.**
     - They should be verbose and use complete words. Avoid omitting essential information for the purpose of keeping the 
       name compact.
+    - Use the surrounding mojang class, field, and method names to infer parameter names. Prefer matching the mojang naming
+      rather than trying to improve on it.
     - {:.small-text} _Examples:_ `BlockPos adjacentPos, BlockPos currentPos`, not `BlockPos pos1, BlockPos pos2`
 
 1. **Avoid abbreivations or acronyms.**
-    - _Exception:_ Common or well-known abbreviations can be used: `IO` (input-output), `Id` (identifier)
+    - _Exception:_ Common or well-known abbreviations can be used: `IO` (input-output), `Id` (identifier).
     - _Exception:_ Names for common classes can be shortened: `BlockPos pos`, `BlockState state`, `WorldGenLevel level`
-
-> **Note about lambda parameters:**
-> 
-> Currently, there is no fullly automated solution for verifying that mapped lambda parameters do not conflict with 
-> parameters (both method and other lambdas) or local variables. Care should be taken when naming and reviewing these.
-> 
-> As a workaround, Parchment has a 'checked' export which, among other things, strips out names for lambda parameters,
-> so projects which require non-conflicting parameter names (such as for recompilation of decompiled source) may use 
-> that instead.
 
 ## Javadocs
 
-When documenting, try to keep explanations simple and concise without sacrificing accuracy. Avoid use of overly complex
+Write sentences for class, method and field javadocs, starting with an uppercase and ending with a period. When
+documenting, try to keep explanations simple and concise without sacrificing accuracy. Avoid use of overly complex
 or lengthy words where simple and short words are sufficient.
 
-Documenting members should be prioritized into the following: public members, then important members, then non-obvious 
-members (commonly, getters which return numbers or opaque objects, such as NBT tags.) Methods should be documented over
-their corresponding fields.
+Descriptions on `@return` and `@param` entries may be incomplete sentences or phrases, such as 
+
+Do not insert line breaks for overlong columns. (The `.mapping` files should use single line `COMMENT` lines unless an
+an explicit line break in the javadoc comment is desired.) Use `<p>` tags on empty `COMMENT` lines if a line break is
+desired in the generated rendered view of the javadocs.
+
 
 {:.list-separation}
 
-1. **Use fully qualified class names in javadoc tags which link to classes or their members.**
-    - Some of these javadoc tags are `{@link}` and `@see`.
+1. **Use complete, meaningful, concise sentences**
+    - Try and keep explanations simple and concise without sacrificing accuracy. Avoid the use of overly complicated 
+      words where short and simple descriptions are sufficient.
+    - Avoid the use of domain specific knowledge that the reader would not be assumed to have if it is not necessary.
+    - Write complete sentences for documentation, starting with an uppercase letter and ending with a period.
+    - _Exception:_ Phrases in `@return` or `@param` may use short phrases that are not sentences.
+      - {:.small-text} _Example:_
+        
+        ```java
+        /**
+         * This is a full sentence. It begins with a capital letter and ends with a period.
+         * Note that the below two tags may, and are allowed, to use short phrases rather than complete sentences.
+         * @param foo the current foo
+         * @return the modified foo
+         */
+        ```
+
+1. **Do not insert unnesecary line breaks.**
+    - Do not manually insert line breaks for long columns, or try and manually hard wrap sentences.
+      - Each new `COMMENT` line will insert a line break in the comment, and column limits are enforced by end mapping consumers.
+    - Do use line breaks if there is a logical need to start a paragraph in the javadoc comment.
+      - {:.small-text} _Example:_
+
+      ```
+      FIELD foo Foo
+        COMMENT This is a comment, it is not wrapped, even though the sentence may be very long.
+        COMMENT This is a second sentence, which starts a new line in the comment.
+      ```
+    
+    - If a new paragraph in the _compiled javadoc_ is desired, use the `<p>` tag on empty lines. This is up to the writer's
+      choice and not enforced. Stay consistient with nearby existing documentation.
+      - {:.small-text} _Example:_
+
+      ```java
+      /**
+       * This is a first paragraph.
+       * <p>
+       * This is the second paragraph.
+       */
+      ```
+
+1. **Linking to other parts of the code.**
+    - Use `@link`, `@see` and `@linkplain` to link to other parts of the code.
+    - When linking to other classes, use the fully qualified class name unless you can assume the class will be imported.
+      This can happen under the following cases:
+      - The class is from the `java.lang` package.
+      - The class is in the same package as the current class.
+      - The class is an inner class of the current class.
     - {:.small-text} _Example:_ `{@link net.minecraft.math.BlockPos}` instead of `{@link BlockPos}`.
 
 1. **Avoid adding overly simple information or "expected knowledge".**


### PR DESCRIPTION
Summary of the changes:

- Fix `delta%` to `delta$`, as the former would be already caught by Enigma, but the latter would not.
- Add a note about matching mojang names over finding better names. (i.e. when people say a name is bad, it may be because the mojang name is bad, but we're keeping it because it matches)
- Remove the note on lambda parameters as it really has nothing to do with standards.
- Add a note about complete sentences
  - Javadocs should use full sentences.
  - Allows the usage (although does not require it) of incomplete sentence phrases (i.e. `@param foo the foo`). in `@param` and `@return`.
- Add a note about line breaks
  - We shouldn't be seeing any column-width based line breaks. (They can look really ugly when formatted in comment form in an IDE due to differences in indentation, column wrapping limits, etc.)
  - Add a note about using `<p>` to start new paragraphs in the rendered javadoc. (Optional for authors, if desired).
- Expanded the portion on linking to other parts of the code
  - Clarify exactly the tags used for linking
  - Clarify the rules for when fully qualified names are required vs. not (including adding exceptions for `java.lang`, same package, or inner class).

Paging @ParchmentMC/mapping-standards because I kinda went ahead and did this after noticing some consistent points in pending PRs. 

I'll also mention I haven't the foggiest idea how to test this besides saying "the markdown looks good yo"