### PR TITLE
Add new dynamic versions table

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,15 +25,16 @@ end
 
 # Windows and JRuby does not include zoneinfo files, so bundle the tzinfo-data gem
 # and associated library.
-platforms :mingw, :x64_mingw, :mswin, :jruby do
+platforms :windows, :jruby do
   gem "tzinfo", "~> 2.0"
   gem "tzinfo-data"
 end
 
 # Performance-booster for watching directories on Windows
-gem "wdm", "~> 0.1.1", :platforms => [:mingw, :x64_mingw, :mswin]
+gem "wdm", "~> 0.2.0", :platforms => [:windows]
 
 # Custom gems
+gem "csv", "~> 3.3.5"
 gem "webrick", "~> 1.7"
 gem "beautiful-jekyll-theme", "6.0.1"
 

--- a/Gemfile
+++ b/Gemfile
@@ -39,4 +39,4 @@ gem "webrick", "~> 1.7"
 gem "beautiful-jekyll-theme", "6.0.1"
 
 # Fix eventmachine on Windows (https://stackoverflow.com/a/65547010/14416954)
-gem "eventmachine", "1.2.7", git: "https://github.com/eventmachine/eventmachine.git", tag: "v1.2.7"
+gem "eventmachine", "1.2.7", git: "https://github.com/eventmachine/eventmachine.git", tag: "v1.2.7", :platforms => [:windows]

--- a/assets/js/versions-table.js
+++ b/assets/js/versions-table.js
@@ -1,0 +1,86 @@
+
+// URL to the Minecraft versions manfiest (JSON)
+const mc_manifest_url = "https://piston-meta.mojang.com/mc/game/version_manifest_v2.json"
+// URL to the Parchment versions endpoint (JSON)
+const parchment_versions_url = "https://versioning.parchmentmc.org/versions"
+
+// Fallback sort key array
+// When the Minecraft versions manifest cannot be fetched to use as the sort key, this array is used instead
+const fallbackSortKey = [ "1.19.3", "1.19.2", "1.18.2", "1.17.1", "1.16.5" ]
+
+// Element ID of the versions table
+const tableId = "versions-table"
+
+//
+//
+//
+
+const table = document.getElementById(tableId)
+if (table === null || table.tagName !== "TABLE") {
+    throw new Error("Couldn't find <table> element with ID " + tableId + ": " + table)
+}
+
+const manifestPromise = fetch(mc_manifest_url)
+    .then(r => {
+        if (!r.ok) throw new Error("Response not OK: ", r)
+        return r.json()
+    })
+    .catch(err => {
+        console.error("Error trying to fetch Minecraft version manifest: ", err)
+        return null
+    })
+
+fetch(parchment_versions_url)
+    .then(r => {
+        if (!r.ok) throw new Error("Response not OK: ", r)
+        return r.json()
+    })
+    .then(versions => handleVersions(versions))
+    .catch(err => console.error("Error trying to fetch Parchment mappings versions: ", err))
+
+async function handleVersions(data) {
+    var sortKey;
+
+    const manifest = await manifestPromise;
+    if (manifest !== null) sortKey = manifest.versions.map(v => v.id)
+    else {
+        console.log("Using fallback sort key array")
+        sortKey = fallbackSortKey
+    }
+
+    const keys = Object.keys(data.releases)
+    keys.sort((a, b) => sortKey.indexOf(a) - sortKey.indexOf(b))
+
+    const tbody = table.getElementsByTagName('tbody')[0]
+
+    const newRows = []
+    for (const versionKey of keys) {
+        const mappingsVersion = data.releases[versionKey]
+        newRows.push(createRow(versionKey, mappingsVersion))
+    }
+    tbody.replaceChildren(...newRows)
+}
+
+function createRow(mcVersion, mappingsVersion) {
+    const row = document.createElement("tr")
+
+    const mcVersionElem = document.createElement("td")
+    {
+        const mcVer = document.createElement("strong")
+        mcVer.textContent = mcVersion
+        mcVer.className = "mc-version"
+        mcVersionElem.appendChild(mcVer)
+    }
+    row.appendChild(mcVersionElem)
+
+    const mappingsVersionElem = document.createElement("td")
+    {
+        const mappingsVer = document.createElement("code")
+        mappingsVer.textContent = mappingsVersion
+        mappingsVer.className = "mappings-version"
+        mappingsVersionElem.appendChild(mappingsVer)
+    }
+    row.appendChild(mappingsVersionElem)
+
+    return row
+}

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,6 +1,8 @@
 ---
 layout: page
 title: Getting Started
+js:
+  - /assets/js/versions-table.js
 ---
 
 ## Choose a version
@@ -31,7 +33,7 @@ The latest version of the release export for a particular Minecraft version can 
 |    **1.18.2**     | ![Latest release version badge for 1.18.2](https://img.shields.io/maven-metadata/v?color=forestgreen&label=release&metadataUrl=https%3A%2F%2Fldtteam.jfrog.io%2Fartifactory%2Fparchmentmc-internal%2Forg%2Fparchmentmc%2Fdata%2Fparchment-1.18.2%2Fmaven-metadata.xml) |
 |    **1.17.1**     | ![Latest release version badge for 1.17.1](https://img.shields.io/maven-metadata/v?color=forestgreen&label=release&metadataUrl=https%3A%2F%2Fldtteam.jfrog.io%2Fartifactory%2Fparchmentmc-internal%2Forg%2Fparchmentmc%2Fdata%2Fparchment-1.17.1%2Fmaven-metadata.xml) |
 |    **1.16.5**     | ![Latest release version badge for 1.16.5](https://img.shields.io/maven-metadata/v?color=forestgreen&label=release&metadataUrl=https%3A%2F%2Fldtteam.jfrog.io%2Fartifactory%2Fparchmentmc-internal%2Forg%2Fparchmentmc%2Fdata%2Fparchment-1.16.5%2Fmaven-metadata.xml) |
-{:style="margin: auto"}
+{:style="margin: auto" #versions-table}
 
 When selecting the Parchment mappings version from the version badges above or in the README, please remove the `v` prefix before inserting it into your buildscript.
 
@@ -164,6 +166,10 @@ ParchmentMC provides the [**Librarian**](https://github.com/ParchmentMC/Libraria
 [exports-info]: /docs/maven#parchment-exports
 
 <style>
+
+#versions-table td {
+    text-align: center;
+}
 
 .version u {
     font-style: italic;


### PR DESCRIPTION
This PR resolves #12 by replacing the existing static versions table with a new dynamic versions table. This makes use of JS and the new Parchment mappings version endpoint to dynamically list out the latest version for each available Minecraft version.

The current implementation sorts the MC versions using the info from the launcher manifest, and falling back to a hardcoded array if that is not available. It also replaces the rows of the table with new rows, so that the original rows (which uses version badges) of the table remain if the script cannot access the versions endpoint.

This PR also does some miscellaneous fixes to the Gemfile for errors and warnings I encountered while installing Jekyll on my Windows machine.

As of PR creation, this is a draft since I am not quite sure of the final UX we want (if we should just have the table be blank if no JS is available, or some instructions pop up to find the latest versions).